### PR TITLE
_config.yml: no 'mailto' in 'email'

### DIFF
--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -8,10 +8,8 @@ carpentry: "swc"
 # Overall title for pages.
 title: "Lesson Title"
 
-# Contact.  This *must* include the protocol: if it's an email
-# address, it must look like "mailto:lessons@software-carpentry.org",
-# or if it's a URL, "https://gitter.im/username/ProjectName".
-email: "mailto:lessons@software-carpentry.org"
+# Email address, no mailto:
+email: "lessons@software-carpentry.org"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).


### PR DESCRIPTION
Closes swcarpentry/styles#283

`site.email` is used as:

_includes/lesson_footer.html:	        <a href="mailto:{{ site.email }}">Contact</a>
_includes/workshop_footer.html:	<a href="mailto:{{ site.email }}">Contact</a>

Therefore, it does not make sense to have `mailto` in the `email` itself.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
